### PR TITLE
Fixed typo in title bar (HelpVeiwer -> HelpViewer)

### DIFF
--- a/qwinhelp.ui
+++ b/qwinhelp.ui
@@ -12,7 +12,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>HelpVeiwer</string>
+   <string>HelpViewer</string>
   </property>
   <widget class="QWidget" name="centralwidget"/>
   <widget class="QMenuBar" name="menubar">


### PR DESCRIPTION
The title bar had a typo in it upon starting the application. This patch fixes it.
Original:
![helpviewer](https://user-images.githubusercontent.com/2400933/59886766-5d367580-938e-11e9-8bd4-23722751447a.png)
